### PR TITLE
Add support for librnp name with a major version.

### DIFF
--- a/lib/rnp/ffi/librnp.rb
+++ b/lib/rnp/ffi/librnp.rb
@@ -7,7 +7,7 @@ require 'ffi'
 # @api private
 module LibRnp
   extend FFI::Library
-  ffi_lib 'rnp'
+  ffi_lib %w[rnp-0 rnp]
 
   callback        :rnp_get_key_cb,
                   %i[pointer pointer string string bool],


### PR DESCRIPTION
If https://github.com/riboseinc/rnp/pull/724 is merged.