### PR TITLE
Update tests to get aligned with changes in rnp PR #743

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
     - LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSONC_INSTALL}/lib:${RNP_INSTALL}/lib"
   matrix:
     - RNP_VERSION=master
-    - RNP_VERSION=v0.9.1
 
 cache:
   bundler: true

--- a/spec/rnp_spec.rb
+++ b/spec/rnp_spec.rb
@@ -93,7 +93,7 @@ describe Rnp do
       rnp.load_keys(format: 'GPG',
                     input: Rnp::Input.from_path('spec/data/keyrings/gpg/secring.gpg'),
                     public_keys: true, secret_keys: false)
-      expect(rnp.keyids.size).to be 0
+      expect(rnp.keyids.size).to be 7
     end
 
     it 'loads only secret keys when specified' do
@@ -172,7 +172,7 @@ describe Rnp do
       expect(rnp.keyids.size).to eql 7
       rnp.keyids.each do |keyid|
         key = rnp.find_key(keyid: keyid)
-        expect(key.public_key_present?).to be false
+        expect(key.public_key_present?).to be true
         expect(key.secret_key_present?).to be true
       end
     end


### PR DESCRIPTION
riboseinc/rnp#743 changes behavior of key loading: now, once secret key is loaded (non-G10), then it's public part is also automatically added to the keyring. So this requires some updates to the tests.