### PR TITLE
Allow to set per-signature parameters and align with rnp PR #781

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSONC_INSTALL}/lib:${RNP_INSTALL}/lib"
   matrix:
     - RNP_VERSION=master
+    - RNP_VERSION=v0.11.0
 
 cache:
   bundler: true

--- a/lib/rnp/ffi/librnp.rb
+++ b/lib/rnp/ffi/librnp.rb
@@ -320,6 +320,14 @@ module LibRnp
     end
   end
 
+  if ffi_libraries[0].find_function('rnp_version_commit_timestamp')
+    attach_function :rnp_version_commit_timestamp, [], :uint64
+  else
+    def self.rnp_version_commit_timestamp
+      0
+    end
+  end
+
   RNP_KEY_EXPORT_ARMORED = (1 << 0)
   RNP_KEY_EXPORT_PUBLIC =  (1 << 1)
   RNP_KEY_EXPORT_SECRET =  (1 << 2)

--- a/lib/rnp/misc.rb
+++ b/lib/rnp/misc.rb
@@ -157,5 +157,16 @@ class Rnp
   def self.commit_time
     LibRnp.rnp_version_commit_timestamp
   end
+
+  FEATURES = {
+    # Support for setting hash, creation, and expiration time for individual
+    # signatures in a sign operation.
+    'per-signature-opts' => Rnp.version > Rnp.version('0.11.0') || Rnp.commit_time >= 1546035818
+  }.freeze
+
+  def self.has?(feature)
+    raise ArgumentError unless FEATURES.include?(feature)
+    FEATURES[feature]
+  end
 end # class
 

--- a/lib/rnp/misc.rb
+++ b/lib/rnp/misc.rb
@@ -112,8 +112,12 @@ class Rnp
   # stamps generated with {version_for}.
   #
   # @return [Integer]
-  def self.version
-    LibRnp.rnp_version
+  def self.version(str = nil)
+    if str.nil?
+      LibRnp.rnp_version
+    else
+      LibRnp.rnp_version_for(*str.split('.').map(&:to_i))
+    end
   end
 
   # Encode the given major, minor, and patch numbers into a version

--- a/lib/rnp/misc.rb
+++ b/lib/rnp/misc.rb
@@ -144,5 +144,14 @@ class Rnp
   def self.version_patch(version)
     LibRnp.rnp_version_patch(version)
   end
+
+  # Retrieve the commit time of the latest commit.
+  #
+  # This will return 0 for release/non-master builds.
+  #
+  # @return [Integer]
+  def self.commit_time
+    LibRnp.rnp_version_commit_timestamp
+  end
 end # class
 

--- a/lib/rnp/op/sign.rb
+++ b/lib/rnp/op/sign.rb
@@ -129,10 +129,12 @@ class Rnp
     # @api private
     def self.set_signature_options(psig, hash:, creation_time:,
                                    expiration_time:)
-      Rnp.call_ffi(:rnp_op_sign_signature_set_hash, psig, value) unless hash.nil?
+      Rnp.call_ffi(:rnp_op_sign_signature_set_hash, psig, hash) unless hash.nil?
       creation_time = creation_time.to_i if creation_time.is_a?(::Time)
-      Rnp.call_ffi(:rnp_op_sign_signature_set_creation_time, psig, value) unless creation_time.nil?
-      Rnp.call_ffi(:rnp_op_sign_signature_set_expiration_time, psig, value) unless expiration_time.nil?
+      Rnp.call_ffi(:rnp_op_sign_signature_set_creation_time, psig,
+                   creation_time) unless creation_time.nil?
+      Rnp.call_ffi(:rnp_op_sign_signature_set_expiration_time, psig,
+                   expiration_time) unless expiration_time.nil?
     end
   end # class
 end # class

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -105,6 +105,14 @@ describe 'versioning', skip: !LibRnp::HAVE_RNP_VERSION do
     it 'returns a number' do
       expect(Rnp.version).to be_kind_of(Integer)
     end
+
+    it 'returns the expected value when taking a string version' do
+      expect(Rnp.version('1.23.4')).to be ((1 << 20) | (23 << 10) | (4 << 0))
+    end
+
+    it 'returns values equivalent to version_for' do
+      expect(Rnp.version('2.35.6')).to be Rnp.version_for(2, 35, 6)
+    end
   end
 
   describe Rnp.method(:version_for) do

--- a/spec/sign/sign_spec.rb
+++ b/spec/sign/sign_spec.rb
@@ -38,11 +38,22 @@ describe Rnp::Verify do
     output = Rnp::Output.to_string
     sign = rnp.start_sign(input: Rnp::Input.from_string('data'),
                           output: output)
+    # these values won't be used, since they're modified later (before execute)
     sign.hash = 'SHA256'
     sign.expiration_time = 120
     sign.add_signer(rnp.find_key(userid: 'key0-uid1'))
-    sign.add_signer(rnp.find_key(userid: 'key1-uid2'), hash: 'SHA256',
-                    expiration_time: 120)
+    sign.add_signer(
+      rnp.find_key(userid: 'key1-uid2'),
+      if Rnp.has?('per-signature-opts')
+        {
+          hash: 'SHA256',
+          expiration_time: 120
+        }
+      else
+        {}
+      end
+    )
+    # these values will be used for sigs that do not explicitly set these
     sign.hash = 'SHA512'
     sign.expiration_time = 60
     rnp.password_provider = 'password'
@@ -65,10 +76,15 @@ describe Rnp::Verify do
     expect(sigs[0].valid?).to be true
     expect(sigs[0].expired?).to be false
 
-    expect(sigs[1].hash).to eql 'SHA256'
+    if Rnp.has?('per-signature-opts')
+      expect(sigs[1].hash).to eql 'SHA256'
+      expect(sigs[1].expiration_time).to eql 120
+    else
+      expect(sigs[1].hash).to eql 'SHA512'
+      expect(sigs[1].expiration_time).to eql 60
+    end
     expect(sigs[1].key.keyid).to eql '2FCADF05FFA501BB'
     expect(Time.now - sigs[0].creation_time).to be <= 5
-    expect(sigs[1].expiration_time).to eql 120
     expect(sigs[1].good?).to be true
     expect(sigs[1].valid?).to be true
     expect(sigs[1].expired?).to be false

--- a/spec/sign/sign_spec.rb
+++ b/spec/sign/sign_spec.rb
@@ -38,8 +38,11 @@ describe Rnp::Verify do
     output = Rnp::Output.to_string
     sign = rnp.start_sign(input: Rnp::Input.from_string('data'),
                           output: output)
+    sign.hash = 'SHA256'
+    sign.expiration_time = 120
     sign.add_signer(rnp.find_key(userid: 'key0-uid1'))
-    sign.add_signer(rnp.find_key(userid: 'key1-uid2'))
+    sign.add_signer(rnp.find_key(userid: 'key1-uid2'), hash: 'SHA256',
+                    expiration_time: 120)
     sign.hash = 'SHA512'
     sign.expiration_time = 60
     rnp.password_provider = 'password'
@@ -62,10 +65,10 @@ describe Rnp::Verify do
     expect(sigs[0].valid?).to be true
     expect(sigs[0].expired?).to be false
 
-    expect(sigs[1].hash).to eql 'SHA512'
+    expect(sigs[1].hash).to eql 'SHA256'
     expect(sigs[1].key.keyid).to eql '2FCADF05FFA501BB'
     expect(Time.now - sigs[0].creation_time).to be <= 5
-    expect(sigs[1].expiration_time).to eql 60
+    expect(sigs[1].expiration_time).to eql 120
     expect(sigs[1].good?).to be true
     expect(sigs[1].valid?).to be true
     expect(sigs[1].expired?).to be false


### PR DESCRIPTION
This PR fixes ruby tests to align with riboseinc/rnp#781 
Also it updates sign.rb to allow to set per-signature parameters.