### PR TITLE
Relax Bundler constraint (allow 2.x)

### DIFF
--- a/rnp.gemspec
+++ b/rnp.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.metadata['yard.run'] = 'yard'
 
   spec.add_development_dependency 'asciidoctor', '~> 1.5'
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '>= 1.14', '< 3'
   spec.add_development_dependency 'codecov', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4'


### PR DESCRIPTION
Bundler 2.0 has been released this month.  This change relaxes the development dependency constraint in order to allow this version. A new constraint which forbids 3.x has been introduced instead.

Keeping the constraint unchanged, apart from being potentially inconvenient for developers, could lead to a problem, which has been observed in other gems developed by Ribose Inc. — some Rubies in Travis CI come with Bundler preinstalled, causing builds to fail if it is Bundler 2.  An alternative solution is to enforce a specific Bundler version in Travis (simply installing it is not enough).  However, allowing Bundler 2 is simpler and cleaner in case of this gem.

This gem does not rely on Bundler except for managing development gems, therefore no regression should happen.