### PR TITLE
Fix HAVE_* constant values.

### DIFF
--- a/lib/rnp/ffi/librnp.rb
+++ b/lib/rnp/ffi/librnp.rb
@@ -305,7 +305,7 @@ module LibRnp
     rnp_version_minor: [%i[uint32], :uint32],
     rnp_version_patch: [%i[uint32], :uint32]
   }.each do |name, signature|
-    present = ffi_libraries[0].find_function(name.to_s)
+    present = !ffi_libraries[0].find_function(name.to_s).nil?
     if !present
       class_eval do
         define_singleton_method(name) do |*|


### PR DESCRIPTION
These were assigned values of either nil or FFI::DynamicLibrary::Symbol, but were really intended to be boolean.

Since these are currently undocumented (TODO!), I don't think a version bump is necessary.