### PR TITLE
Remove has_rdoc from gemspec

### DIFF
--- a/rnp.gemspec
+++ b/rnp.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.has_rdoc = 'yard'
   spec.metadata['yard.run'] = 'yard'
 
   spec.add_development_dependency 'asciidoctor', '~> 1.5'


### PR DESCRIPTION
Gem specification attribute #has_rdoc is deprecated and ignored. According to deprecation warning, it may be removed "on or after 2018-12-01" with no replacement.

This attribute used to describe whether RDoc can be generated for given gem or not.  According to RubyGems v1.3.3 release notes, "RDoc is now generated regardless of Gem::Specification#has_rdoc?".

See:
- https://blog.rubygems.org/2009/05/04/1.3.3-released.html